### PR TITLE
Add attribute to select initial expanded mode

### DIFF
--- a/expandlayout-library/res/values/attrs.xml
+++ b/expandlayout-library/res/values/attrs.xml
@@ -3,6 +3,7 @@
 
     <declare-styleable name="ExpandableLayout">
         <attr name="canExpand" format="boolean" />
+        <attr name="expanded" format="boolean" />
     </declare-styleable>
 
 </resources>

--- a/expandlayout-library/src/com/sherlock/expandlayout/ExpandableLayout.java
+++ b/expandlayout-library/src/com/sherlock/expandlayout/ExpandableLayout.java
@@ -458,6 +458,8 @@ public class ExpandableLayout extends LinearLayout {
 					R.styleable.ExpandableLayout);
 			canExpand = a.getBoolean(R.styleable.ExpandableLayout_canExpand,
 					false);
+			isExpanded = a.getBoolean(R.styleable.ExpandableLayout_expanded,
+					false);
 			originalHeight = this.height;
 			a.recycle();
 		}


### PR DESCRIPTION
This patch allows the user to set in XML if the view should start expanded using a simple `app:expanded="true"` tag.

It also makes it easier to preview the design of the expanded layout by applying the tag at design time and then removing it (or setting it to false) before building.
