### PR TITLE
Avoid clashing attribute with support lib

### DIFF
--- a/expandlayout-library/res/values/attrs.xml
+++ b/expandlayout-library/res/values/attrs.xml
@@ -3,7 +3,7 @@
 
     <declare-styleable name="ExpandableLayout">
         <attr name="canExpand" format="boolean" />
-        <attr name="expanded" format="boolean" />
+        <attr name="startExpanded" format="boolean" />
     </declare-styleable>
 
 </resources>

--- a/expandlayout-library/src/com/sherlock/expandlayout/ExpandableLayout.java
+++ b/expandlayout-library/src/com/sherlock/expandlayout/ExpandableLayout.java
@@ -458,7 +458,7 @@ public class ExpandableLayout extends LinearLayout {
 					R.styleable.ExpandableLayout);
 			canExpand = a.getBoolean(R.styleable.ExpandableLayout_canExpand,
 					false);
-			isExpanded = a.getBoolean(R.styleable.ExpandableLayout_expanded,
+			isExpanded = a.getBoolean(R.styleable.ExpandableLayout_startExpanded,
 					false);
 			originalHeight = this.height;
 			a.recycle();


### PR DESCRIPTION
The "enabled" attribute is already defined in the Android design support
library and reusing it causes build failures.
